### PR TITLE
Using cache instead of session to store the user token and access

### DIFF
--- a/src/Backend/Backend.API/Controllers/Authentication/AuthenticationController.cs
+++ b/src/Backend/Backend.API/Controllers/Authentication/AuthenticationController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using static Backend.Infrastructure.Services.Authorization.AuthorizationService;
 using Backend.Domain.Entities.Authentication.Users.Login.Response;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Backend.API.Controllers.Authentication
 {
@@ -18,11 +19,13 @@ namespace Backend.API.Controllers.Authentication
         private readonly AuthenticationService _authenticationService;
         private readonly AuthorizationService _authorizationService;
         private readonly UserContextService _userContextService;
-        public AuthenticationController(AuthenticationService authenticationService, AuthorizationService authorizationService, UserContextService userContextService) 
+        private readonly IMemoryCache _cache;
+        public AuthenticationController(AuthenticationService authenticationService, AuthorizationService authorizationService, UserContextService userContextService, IMemoryCache cache) 
         { 
             _authenticationService = authenticationService;
             _authorizationService = authorizationService;
             _userContextService = userContextService;
+            _cache = cache;
         }
 
         [HttpPost]
@@ -43,7 +46,8 @@ namespace Backend.API.Controllers.Authentication
                     Levels = _userContextService.VerifyUserRequest(userPermissions),
                     Success = true
                 };
-                Util.Session.Extensions.SessionExtensions.Set(HttpContext.Session, "UserContext", userContext);
+
+                _cache.Set(userContext.Token,userContext);
                 return Ok(userContext);
             }
             else

--- a/src/Backend/Backend.API/Controllers/Authentication/AuthenticationController.cs
+++ b/src/Backend/Backend.API/Controllers/Authentication/AuthenticationController.cs
@@ -47,7 +47,8 @@ namespace Backend.API.Controllers.Authentication
                     Success = true
                 };
 
-                _cache.Set(userContext.Token,userContext);
+                // It will store the userContext on the cache and it can be found by getting it using the token
+                _cache.Set(userContext.Token,userContext,TimeSpan.FromHours(4));
                 return Ok(userContext);
             }
             else

--- a/src/Backend/Backend.API/Controllers/Products/ProductController.cs
+++ b/src/Backend/Backend.API/Controllers/Products/ProductController.cs
@@ -20,7 +20,7 @@ namespace Backend.API.Controllers.Products
             _userContextService = userContextService;
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpGet]
         [Route("List")]
         public async Task<ActionResult> Get(Guid tenantId)
@@ -34,7 +34,7 @@ namespace Backend.API.Controllers.Products
                 throw ex;
             }
         }
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpGet]
         [Route("Find")]
         public async Task<ActionResult> GetById(Guid tenantId, Guid productId)
@@ -49,7 +49,7 @@ namespace Backend.API.Controllers.Products
                 throw ex;
             }
         }
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPost]
         [Route("Add")]
         public async Task<ActionResult> Add(Product product)
@@ -68,7 +68,7 @@ namespace Backend.API.Controllers.Products
                 throw ex;
             }
         }
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPut]
         [Route("Update")]
         public async Task<ActionResult> Update(Product product)
@@ -84,7 +84,7 @@ namespace Backend.API.Controllers.Products
                 throw ex;
             }
         }
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPut]
         [Route("Delete")]
         public async Task<ActionResult> Delete(Guid Id)

--- a/src/Backend/Backend.API/Controllers/Products/ProductTypeController.cs
+++ b/src/Backend/Backend.API/Controllers/Products/ProductTypeController.cs
@@ -18,7 +18,7 @@ namespace Backend.API.Controllers
             _userContextService = userContextService;
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpGet]
         [Route("List")]
         public async Task<ActionResult> Get()
@@ -34,7 +34,7 @@ namespace Backend.API.Controllers
             }
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpGet]
         [Route("Find")]
         public async Task<ActionResult> GetById(Guid Id)
@@ -50,7 +50,7 @@ namespace Backend.API.Controllers
             }
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPost]
         [Route("Add")]
         public async Task<ActionResult> Add(ProductType productType)
@@ -67,7 +67,7 @@ namespace Backend.API.Controllers
             }
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPut]
         [Route("Update")]
         public async Task<ActionResult> Update(ProductType productType)
@@ -84,7 +84,7 @@ namespace Backend.API.Controllers
             }
         }
 
-        [ValidateUserContext]
+        [TypeFilter(typeof(ValidateUserContextAttribute))]
         [HttpPut]
         [Route("Delete")]
         public async Task<ActionResult> Delete(Guid Id)

--- a/src/Backend/Backend.API/Helpers/Attributes/UserContextValidation/UserContextValidationAttribute.cs
+++ b/src/Backend/Backend.API/Helpers/Attributes/UserContextValidation/UserContextValidationAttribute.cs
@@ -37,6 +37,9 @@ public class ValidateUserContextAttribute : ActionFilterAttribute
             return; // Fuck off 
         }
 
+        // If the user is authenticated it will refresh the token on the cache to extend it's duration
+        _cache.Set(userContext.Token,userContext,TimeSpan.FromHours(4));
+
         if (tokenRequest == userContext.Token)
         {
             foreach (var access in userContext.Levels) // i have no idea on wtf im doing | << chill out you doing fine

--- a/src/Backend/Backend.API/Helpers/Attributes/UserContextValidation/UserContextValidationAttribute.cs
+++ b/src/Backend/Backend.API/Helpers/Attributes/UserContextValidation/UserContextValidationAttribute.cs
@@ -3,14 +3,20 @@ using Backend.Domain.Entities.Authentication.Users.UserContext;
 using Backend.Infrastructure.Services.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
 using SessionExtensions = Backend.API.Util.Session.Extensions.SessionExtensions;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class ValidateUserContextAttribute : ActionFilterAttribute
 {
+    private readonly IMemoryCache _cache;
+    public ValidateUserContextAttribute(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
     public override void OnActionExecuting(ActionExecutingContext context)
     {
-        var tokenRequest = context.HttpContext.Request.Headers.Authorization;
+        string tokenRequest = context.HttpContext.Request.Headers.Authorization.ToString();
      
         /* 
          * BUG - 4/10/23
@@ -18,7 +24,7 @@ public class ValidateUserContextAttribute : ActionFilterAttribute
          * when saving the session in the API app runs, it's not saving it.
          * need to figure out WHY the context API is not being saved when login is triggered by the UI.
          */
-        var userContext = SessionExtensions.Get<UserSessionContext>(context.HttpContext.Session, "UserContext");
+        var userContext = _cache.Get<UserSessionContext>(tokenRequest);
 
         // If there is no userContext it probably mean the user is not fucking logged in
         if (userContext == null)

--- a/src/Backend/Backend.API/Program.cs
+++ b/src/Backend/Backend.API/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddDbContext<AuthDbContext>(o => o.UseNpgsql(builder.Configurat
 builder.Services.AddSession(o => o.IdleTimeout = TimeSpan.FromMinutes(60));
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddDistributedMemoryCache(); // Use in-memory cache for session data
+builder.Services.AddMemoryCache();
 
 /* Authentication & Authorization Middleware section */
 // Authenticate
@@ -113,8 +114,6 @@ builder.Services.AddAuthorization();
 
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
-builder.Services.AddHttpContextAccessor();
-builder.Services.AddMemoryCache();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle


### PR DESCRIPTION
Major changes for how the token is being used. 
The way it was before there was a problem with clients using the application because it relied on the session cookies to get the current user context. The problem was some clients weren't browsers so they didn't get the cookies, therefore we couldn't use the old system.
Now it will use the cache system to store and get the user session only based on the token. When the user is authenticated it will save all of his information and accesses on the cache, the cache can be retrieved by using his token on the Authorization header. The token will expire every 4 hours, but every time the token is used it will reset this expiration time.